### PR TITLE
Migrate zend-validator to laminas-validator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,15 @@
   "type": "library",
   "description": "email-parse a (reasonably) RFC822 / RF2822-compliant library for batch parsing multiple (and single) email addresses",
   "license": "MIT",
-  "keywords": ["email", "parse", "RFC822", "RFC2822", "email-parse", "multiple-email", "batch-email"],
+  "keywords": [
+    "email",
+    "parse",
+    "RFC822",
+    "RFC2822",
+    "email-parse",
+    "multiple-email",
+    "batch-email"
+  ],
   "authors": [
     {
       "name": "Matthew J. Mucklo",
@@ -19,11 +27,12 @@
     "php": ">=7.1",
     "true/punycode": "~2.0",
     "psr/log": "~1.0",
-    "zendframework/zend-validator" : ">=2.0,<=3.0"
+    "laminas/laminas-validator": ">=2.0,<=3.0",
+    "laminas/laminas-dependency-plugin": "^1.0"
   },
   "autoload": {
     "psr-4": {
-	    "Email\\": "src/"
+      "Email\\": "src/"
     }
   },
   "config": {
@@ -31,8 +40,7 @@
   },
   "autoload-dev": {
     "psr-4": {
-	    "Email\\Tests\\": "tests/"
+      "Email\\Tests\\": "tests/"
     }
   }
 }
-

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,7 @@
     "php": ">=7.1",
     "true/punycode": "~2.0",
     "psr/log": "~1.0",
-    "laminas/laminas-validator": ">=2.0,<=3.0",
-    "laminas/laminas-dependency-plugin": "^1.0"
+    "laminas/laminas-validator": "^2.13"
   },
   "autoload": {
     "psr-4": {

--- a/src/Parse.php
+++ b/src/Parse.php
@@ -2,7 +2,7 @@
 
 namespace Email;
 
-use Zend\Validator\Ip;
+use Laminas\Validator\Ip;
 use Psr\Log\LoggerInterface;
 use TrueBV\Punycode;
 


### PR DESCRIPTION
Used the [migrate tool](https://docs.laminas.dev/migration/) with minor cleanups:

```
$ laminas-migration migrate
```

Refs: https://github.com/mmucklo/email-parse/issues/20