### PR TITLE
Replace punycode and update dependancies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,11 @@ composer.lock
 # composer
 vendor/*
 
+# phpunit
+/.phpunit.result.cache
+
 # bin
+/bin
 bin/php-cs-fixer
 bin/phpunit
 bin/yaml-lint

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
   },
   "require": {
     "php": ">=7.1|^8.0",
-    "true/punycode": "~2.0",
     "psr/log": "~1.0|~2.0|~3.0",
     "laminas/laminas-validator": "^2.13",
     "ext-mbstring": "*",

--- a/composer.json
+++ b/composer.json
@@ -19,16 +19,17 @@
     }
   ],
   "require-dev": {
-    "phpunit/phpunit": "^7",
+    "phpunit/phpunit": "^7|^8|^9",
     "friendsofphp/php-cs-fixer": "^3.0|^2.0",
     "symfony/yaml": ">=4"
   },
   "require": {
-    "php": ">=7.1",
+    "php": ">=7.1|^8.0",
     "true/punycode": "~2.0",
-    "psr/log": "~1.0",
+    "psr/log": "~1.0|~2.0|~3.0",
     "laminas/laminas-validator": "^2.13",
-    "ext-mbstring": "*"
+    "ext-mbstring": "*",
+    "symfony/polyfill-intl-idn": "^1.27"
   },
   "autoload": {
     "psr-4": {

--- a/src/Parse.php
+++ b/src/Parse.php
@@ -4,7 +4,6 @@ namespace Email;
 
 use Laminas\Validator\Ip;
 use Psr\Log\LoggerInterface;
-use TrueBV\Punycode;
 
 /**
  * Class Parse.
@@ -40,8 +39,6 @@ class Parse
      */
     protected $logger = null;
 
-    protected $punycode;
-
     /**
      * @var ParseOptions
      */
@@ -72,18 +69,6 @@ class Parse
     {
         $this->logger = $logger;
         $this->options = $options ?: new ParseOptions(['%', '!']);
-    }
-
-    /**
-     * @return Punycode
-     */
-    public function getPunycode()
-    {
-        if (!$this->punycode) {
-            $this->punycode = new Punycode();
-        }
-
-        return $this->punycode;
     }
 
     /**
@@ -497,7 +482,7 @@ class Parse
                             try {
                                 // Test by trying to encode the current character into Punycode
                                 // Punycode should match the traditional domain name subset of characters
-                                if (preg_match('/[a-z0-9\-]/', $this->getPunycode()->encode($curChar))) {
+                                if (preg_match('/[a-z0-9\-]/', idn_to_ascii($curChar))) {
                                     $emailAddress['domain'] .= $curChar;
                                 } else {
                                     $emailAddress['invalid'] = true;
@@ -784,7 +769,7 @@ class Parse
                 // Check for IDNA
                 if (max(array_keys(count_chars($emailAddress['domain'], 1))) > 127) {
                     try {
-                        $emailAddress['domain'] = $this->getPunycode()->encode($emailAddress['domain']);
+                        $emailAddress['domain'] = idn_to_ascii($emailAddress['domain']);
                     } catch (\Exception $e) {
                         $emailAddress['invalid'] = true;
                         $emailAddress['invalid_reason'] = "Can't convert domain {$emailAddress['domain']} to punycode";


### PR DESCRIPTION
This PR replaces the unmaintained true/punycode with symfony/polyfill-intl-idn to achieve the same results.

Also updates dependancies be able to use the package with modern frameworks where psr/log ~2.0 or ~3.0 is used.

Tested on PHP7.1 -> PHP8.1; tests clear and updates in this PR should be backwards compatible.