### PR TITLE
Add Psalm cross-check alongside PHPStan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,4 +119,26 @@ jobs:
         run: composer install --prefer-dist --no-progress --no-suggest
 
       - name: Run PHPStan
-        run: bin/phpstan analyse --error-format=github
+        run: bin/phpstan analyse --memory-limit=512M --error-format=github
+
+  psalm:
+    name: Static Analysis (Psalm)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: mbstring, intl
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-suggest
+
+      - name: Run Psalm
+        run: bin/psalm --memory-limit=512M --output-format=github

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -14,6 +14,11 @@ checks:
 
 build:
     image: default-jammy
+    environment:
+        php: 8.2
+    dependencies:
+        override:
+            - composer install --no-interaction --no-scripts --ignore-platform-reqs
     nodes:
         analysis:
             tests:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -88,7 +88,7 @@ Not tied to a specific release; picked up as time allows.
 
 **Static analysis:**
 - [x] PHPStan level 6 → 8 — tighter generics and inference; required four small nullable-return guards (`idn_to_ascii`, `mb_split`, `file_get_contents`) and one local docblock shape on `parseMultiple()`.
-- [ ] Add Psalm alongside PHPStan for cross-tool coverage; keep both green.
+- [x] Psalm alongside PHPStan — level 3 with baseline (66 entries, all false positives or duplicates of PHPStan findings). Found no genuinely new bugs vs PHPStan level 8; serves as a cross-check for future regressions. `composer psalm`.
 
 **Performance:**
 - [x] PhpBench suite — `benchmarks/ParseBench.php` covers single ASCII, name-addr, UTF-8 local-part, IDN, obs-route, 10-address comma batch, 100-address `parseStream` batch, invalid inputs, and comment extraction. Run with `composer bench`.

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
     "phpunit/phpunit": "^9.6",
     "symfony/yaml": "^6.4|^7.2",
     "infection/infection": "^0.29.8",
-    "phpbench/phpbench": "^1.4"
+    "phpbench/phpbench": "^1.4",
+    "vimeo/psalm": "^6.0"
   },
   "require": {
     "php": "^8.1",
@@ -59,6 +60,7 @@
     "cs:check": "php-cs-fixer fix --dry-run --diff",
     "cs:fix": "php-cs-fixer fix",
     "stan": "phpstan analyse --memory-limit=512M",
+    "psalm": "psalm --memory-limit=512M",
     "infect": "XDEBUG_MODE=coverage infection --threads=max",
     "bench": "phpbench run --report=default",
     "ci": [

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="6.16.1@f1f5de594dc76faf8784e02d3dc4716c91c6f6ac">
+  <file src="src/LengthLimits.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[createRelaxed]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="src/Parse.php">
+    <InvalidScalarArgument>
+      <code><![CDATA[$origEncoding]]></code>
+    </InvalidScalarArgument>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$tempIp]]></code>
+    </PossiblyInvalidArgument>
+    <PossiblyInvalidCast>
+      <code><![CDATA[$tempIp]]></code>
+    </PossiblyInvalidCast>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$emailAddress['address_temp']]]></code>
+      <code><![CDATA[$emailAddress['address_temp']]]></code>
+      <code><![CDATA[$emailAddress['address_temp']]]></code>
+      <code><![CDATA[$emailAddress['invalid']]]></code>
+      <code><![CDATA[$emailAddress['local_part_parsed']]]></code>
+      <code><![CDATA[$emailAddress['name_parsed']]]></code>
+      <code><![CDATA[$emailAddress['name_parsed']]]></code>
+    </PossiblyUndefinedArrayOffset>
+    <PossiblyUnusedMethod>
+      <code><![CDATA[getInstance]]></code>
+      <code><![CDATA[getOptions]]></code>
+      <code><![CDATA[parseMultiple]]></code>
+      <code><![CDATA[parseSingle]]></code>
+      <code><![CDATA[parseStream]]></code>
+      <code><![CDATA[setLogger]]></code>
+      <code><![CDATA[setOptions]]></code>
+    </PossiblyUnusedMethod>
+    <RedundantCondition>
+      <code><![CDATA[self::STATE_START == $subState]]></code>
+    </RedundantCondition>
+    <TypeDoesNotContainType>
+      <code><![CDATA[self::STATE_NAME == $subState]]></code>
+      <code><![CDATA[self::STATE_NAME == $subState]]></code>
+      <code><![CDATA[self::STATE_NAME === $subState]]></code>
+      <code><![CDATA[self::STATE_NAME === $subState]]></code>
+    </TypeDoesNotContainType>
+    <UnusedFunctionCall>
+      <code><![CDATA[mb_regex_encoding]]></code>
+      <code><![CDATA[mb_regex_encoding]]></code>
+    </UnusedFunctionCall>
+  </file>
+  <file src="src/ParseOptions.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[getMaxDomainLabelLength]]></code>
+      <code><![CDATA[getMaxLocalPartLength]]></code>
+      <code><![CDATA[getMaxTotalLength]]></code>
+      <code><![CDATA[rfc2822]]></code>
+      <code><![CDATA[rfc5321]]></code>
+      <code><![CDATA[rfc5322]]></code>
+      <code><![CDATA[rfc6531]]></code>
+      <code><![CDATA[setBannedChars]]></code>
+      <code><![CDATA[setLengthLimits]]></code>
+      <code><![CDATA[setMaxDomainLabelLength]]></code>
+      <code><![CDATA[setMaxLocalPartLength]]></code>
+      <code><![CDATA[setMaxTotalLength]]></code>
+      <code><![CDATA[setSeparators]]></code>
+      <code><![CDATA[setUseWhitespaceAsSeparator]]></code>
+      <code><![CDATA[withAllowDomainLiteral]]></code>
+      <code><![CDATA[withAllowObsLocalPart]]></code>
+      <code><![CDATA[withAllowObsRoute]]></code>
+      <code><![CDATA[withAllowQuotedString]]></code>
+      <code><![CDATA[withAllowUtf8Domain]]></code>
+      <code><![CDATA[withAllowUtf8LocalPart]]></code>
+      <code><![CDATA[withApplyNfcNormalization]]></code>
+      <code><![CDATA[withBannedChars]]></code>
+      <code><![CDATA[withEnforceLengthLimits]]></code>
+      <code><![CDATA[withIncludeDomainAscii]]></code>
+      <code><![CDATA[withLengthLimits]]></code>
+      <code><![CDATA[withLocalPartNormalizer]]></code>
+      <code><![CDATA[withRejectC0Controls]]></code>
+      <code><![CDATA[withRejectC1Controls]]></code>
+      <code><![CDATA[withRejectEmptyQuotedLocalPart]]></code>
+      <code><![CDATA[withRequireFqdn]]></code>
+      <code><![CDATA[withSeparators]]></code>
+      <code><![CDATA[withStrictIdna]]></code>
+      <code><![CDATA[withUseWhitespaceAsSeparator]]></code>
+      <code><![CDATA[withValidateDisplayNamePhrase]]></code>
+      <code><![CDATA[withValidateIpGlobalRange]]></code>
+      <code><![CDATA[withValidateQuotedContent]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="src/ParseResult.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[toJson]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="src/ParsedEmailAddress.php">
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function __toString(): string]]></code>
+    </MissingOverrideAttribute>
+    <PossiblyUnusedMethod>
+      <code><![CDATA[canonical]]></code>
+      <code><![CDATA[invalidSeverity]]></code>
+      <code><![CDATA[toJson]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+</files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="3"
+    resolveFromConfigFile="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    findUnusedBaselineEntry="true"
+    findUnusedCode="true"
+    errorBaseline="psalm-baseline.xml"
+>
+    <projectFiles>
+        <directory name="src" />
+        <ignoreFiles>
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
+</psalm>


### PR DESCRIPTION
## Summary

Adds Psalm level 3 as a secondary static-analysis tool alongside PHPStan level 8. Both are now green.

## Findings

Psalm found **no genuinely new bugs** that PHPStan level 8 missed. All 66 baseline entries are:

| Category | Count | Status |
|----------|-------|--------|
| PossiblyUnusedMethod (public API) | 48 | False positive — Psalm only scans `src/`, not test callers |
| PossiblyUndefinedArrayOffset | 7 | False positive — `buildEmailAddressArray()` initializes all keys |
| TypeDoesNotContainType / RedundantCondition | 5 | Duplicate of PHPStan baseline (state-machine tautologies) |
| UnusedFunctionCall (mb_regex_encoding) | 2 | Save/restore pattern; return value intentionally unused |
| PossiblyInvalidCast/Argument | 2 | `str_replace` return on typed-string input; false positive |
| MissingOverrideAttribute | 1 | PHP 8.3+ only; not applicable at ^8.1 |
| InvalidScalarArgument | 1 | `mb_regex_encoding($origEncoding)` type — already guarded |

**Value**: cross-check safety net. New code that triggers a Psalm error outside the baseline will surface during review even if PHPStan doesn't flag it.

## Also

Dependabot alert #1 (PHPUnit GHSA-qrr6-mg7r-m243) dismissed as tolerable risk: dev-only dependency, vulnerability requires process-isolation mode which we don't use, fix requires PHP 8.3+ which would drop our 8.1/8.2 support.

## New files

- `psalm.xml` — level 3, scans `src/`
- `psalm-baseline.xml` — 66 entries
- `composer psalm` script

## Test plan

- [x] `composer ci` passes (84 tests / 3,271 assertions)
- [x] `composer psalm` passes with zero errors above baseline
- [x] `composer stan` still passes at level 8