### PR TITLE
Perf: hoist loop-invariant option getters out of the main loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 - **Performance**: the main parse loop splits the input once via `mb_str_split()` instead of calling `mb_substr($emails, $i, 1, $encoding)` on every character (and every look-ahead). For multi-byte encodings each `mb_substr` rescanned from the start of the string — O(n) per call, O(n²) over the loop; the single split is O(n). ~10–27% faster across the benchmark suite, with the largest gains on longer inputs (batch parsing, obs-route, comment extraction). No behavioral change.
+- **Performance**: hoisted the immutable separator, banned-character, and whitespace-separator config out of the per-character loop. These getters returned the same value on every character; fetching them once before the loop removes a method call (and its surrounding opcodes) per character — a further ~19% on a mixed-input micro-benchmark. No behavioral change.
 
 ## [3.3.2]
 

--- a/src/Parse.php
+++ b/src/Parse.php
@@ -292,6 +292,12 @@ class Parse
             $success = false;
             $reason = 'No emails passed in';
         }
+        // Hoist the immutable separator/banned-char config out of the per-character
+        // loop — these getters return the same value every iteration, so fetching
+        // them once avoids a method call (and array return) on every character.
+        $separators = $this->options->getSeparators();
+        $bannedChars = $this->options->getBannedChars();
+        $useWhitespaceAsSeparator = $this->options->getUseWhitespaceAsSeparator();
         $curChar = null;
         for ($i = 0; $i < $len; ++$i) {
             $prevChar = $curChar; // Previous Character
@@ -300,10 +306,10 @@ class Parse
                 case self::STATE_SKIP_AHEAD:
                     // Skip ahead is set when a bad email address is encountered
                     //  It's supposed to skip to the next delimiter and continue parsing from there
-                    $isWhitespaceSeparator = $this->options->getUseWhitespaceAsSeparator() &&
+                    $isWhitespaceSeparator = $useWhitespaceAsSeparator &&
                         (' ' == $curChar || "\r" == $curChar || "\n" == $curChar || "\t" == $curChar);
 
-                    if ($multiple && ($isWhitespaceSeparator || isset($this->options->getSeparators()[$curChar]))) {
+                    if ($multiple && ($isWhitespaceSeparator || isset($separators[$curChar]))) {
                         $state = self::STATE_END_ADDRESS;
                     } else {
                         $emailAddress['original_address'] .= $curChar;
@@ -334,7 +340,7 @@ class Parse
                     }
                     // no break
                 case self::STATE_ADDRESS:
-                    if (!isset($this->options->getSeparators()[$curChar]) || !$multiple) {
+                    if (!isset($separators[$curChar]) || !$multiple) {
                         $emailAddress['original_address'] .= $curChar;
                     }
 
@@ -344,7 +350,7 @@ class Parse
                         $commentNestLevel = 1;
 
                         break;
-                    } elseif (isset($this->options->getSeparators()[$curChar])) {
+                    } elseif (isset($separators[$curChar])) {
                         // Handle separator (comma, semicolon, etc.)
                         if ($multiple && (self::STATE_DOMAIN == $subState || self::STATE_AFTER_DOMAIN == $subState)) {
                             // If we're already in the domain part, this should be the end of the address
@@ -439,7 +445,7 @@ class Parse
                             // Trailing CFWS inside angle-addr before `>`: "<local@domain >".
                             // Absorb and transition as if we saw `>` next.
                             $subState = self::STATE_AFTER_DOMAIN;
-                        } elseif ($this->options->getUseWhitespaceAsSeparator() &&
+                        } elseif ($useWhitespaceAsSeparator &&
                                   (self::STATE_DOMAIN == $subState || self::STATE_AFTER_DOMAIN == $subState)) {
                             // Already past `@` and whitespace-as-separator: end address.
                             $state = self::STATE_END_ADDRESS;
@@ -583,7 +589,7 @@ class Parse
                     } elseif (preg_match('/[A-Za-z0-9_\-!#$%&\'*+\/=?^`{|}~]/', $curChar)) {
                         // RFC 5322 §3.2.3: atext characters — valid in unquoted local-parts and display names
 
-                        if (isset($this->options->getBannedChars()[$curChar])) {
+                        if (isset($bannedChars[$curChar])) {
                             $emailAddress['invalid'] = true;
                             $emailAddress['invalid_reason'] = "This character is not allowed in email addresses submitted (please put in quotes if needed): '{$curChar}'";
                             $emailAddress['invalid_reason_code'] = Err::CharacterNotAllowed;


### PR DESCRIPTION
Profile-driven follow-up to the `mb_str_split` change (#60). An Xdebug profile showed the remaining cost concentrated in the state-machine loop body, with `ParseOptions` getters (`getSeparators` 1.5%, `getBannedChars`, `getUseWhitespaceAsSeparator`) called **inside** the per-character loop.

## Change

Those three getters return immutable config that cannot change during a `parse()` call, yet they were invoked on every character (a few times per character in the hot states — `isset(getSeparators()[$curChar])` etc.). Fetch them once into locals before the loop:

```php
$separators = $this->options->getSeparators();
$bannedChars = $this->options->getBannedChars();
$useWhitespaceAsSeparator = $this->options->getUseWhitespaceAsSeparator();
```

This removes a method call and its surrounding opcodes from every character iteration — the gain is larger than the getters' own self-time because it also shrinks the enclosing `parse()` loop-body opcode count.

## Result

**~19% faster** on a mixed-input micro-benchmark (87.8 → 71.0 μs/parse), on top of #60. The benchmark CI job on this PR measures head-vs-master per subject automatically.

## Safety

- Immutable during a parse: no `ParseOptions` setter runs mid-`parse()`, so the hoisted values are loop-invariant.
- Behavior-preserving: all **91 tests pass**, PHPStan level 8 / cs clean.

## Context: diminishing returns

For transparency — the profile also confirmed the low-hanging fruit is now gone:
- `mb_str_split` is only ~0.3% of parse time; an ASCII `str_split` fast-path measured **net-negative** (the ASCII-detection check costs more than it saves).
- `idn_to_ascii` is ~0.7% (already ASCII-fast-pathed), NFC only runs in intl modes.

Remaining cost is spread across the state machine and per-address object construction. Further gains would need structural changes (e.g. reworking the result-object building) with more risk for less reward.
