### PR TITLE
Gold-standard conformance: structural fixes, whitespace policy, perf restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+Structural over-acceptance bugs surfaced by gold-standard differential testing (dominicsayers/isemail corpus):
+- **Unclosed domain literal** — `test@[1.2.3.4` (no closing `]`) is now rejected (`UnterminatedSquareBracket`). The end-of-input unterminated-delimiter check is now keyed on the parser state rather than on `quote_temp`, so unclosed brackets, comments, and obs-routes are all caught.
+- **Unbalanced nested comment** — a leading comment now opens at nest level 1 (matching the in-address entry), so `((comment)test@…` is no longer treated as closed after a single `)`.
+- **atext/quote abutting a quoted-string** — `"test"test@…` and `"test""test"@…` are now rejected (`AtextAfterQuotedString`, a new `ParseErrorCode`); a quoted-string is a whole word (RFC 5322 §3.2.4). `"word".atom` (obs `word "." word`) stays valid.
+
 ## [3.5.0]
 
 Local-part correctness and configurability. **Heads-up:** `rfc5322()` is now stricter about dot placement (see Changed) — a behavior change for callers relying on the previous permissive dot handling; the old behavior is one builder call away.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Structural over-acceptance bugs surfaced by gold-standard differential testing (
 - **Unclosed domain literal** — `test@[1.2.3.4` (no closing `]`) is now rejected (`UnterminatedSquareBracket`). The end-of-input unterminated-delimiter check is now keyed on the parser state rather than on `quote_temp`, so unclosed brackets, comments, and obs-routes are all caught.
 - **Unbalanced nested comment** — a leading comment now opens at nest level 1 (matching the in-address entry), so `((comment)test@…` is no longer treated as closed after a single `)`.
 - **atext/quote abutting a quoted-string** — `"test"test@…` and `"test""test"@…` are now rejected (`AtextAfterQuotedString`, a new `ParseErrorCode`); a quoted-string is a whole word (RFC 5322 §3.2.4). `"word".atom` (obs `word "." word`) stays valid.
+- **Restored the v3.4.0 main-loop optimizations** — `mb_str_split()` single-pass tokenization and loop-invariant getter hoisting were accidentally reverted in the v3.4.0 release commit and shipped missing in 3.4.0/3.5.0. Reinstated.
+
+### Added
+- **Configurable whitespace policy.** `ParseOptions::$allowedWhitespace` (default `[' ', "\t", "\r", "\n"]`) defines which whitespace characters are treated as insignificant (folding/separators; trimmable); restrict it to enforce strictness (e.g. `[' ', "\t", "\n"]` to reject a lone CR). Builder: `withAllowedWhitespace()`.
+- **Single-address whitespace strictness.** In single-address parsing (`parseSingle` / `parse(..., multiple: false)`), CR and LF surrounding the address are now rejected by default — a lone addr-spec has no line endings; spaces/tabs still trim. `ParseOptions::$trimSingleAddressWhitespace` (`withTrimSingleAddressWhitespace(true)`) opts back into liberal trimming. Multi-address parsing is unchanged: CR/LF act as separators per the policy.
 
 ## [3.5.0]
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -90,14 +90,14 @@ Not tied to a specific release; picked up as time allows.
 
 Differential testing against the `dominicsayers/isemail` reference corpus (164 cases) and a reference RFC validator surfaced a set of over-acceptance edge cases — inputs the parser currently treats as valid that the reference standard rejects. Clustered by root cause, in rough priority order:
 
-- [ ] **Comment (CFWS) parsing** — unclosed comments (`((comment)test@`, `test@iana.org(comment\`) and atext after a comment in the local part (`test(comment)test@`) are wrongly accepted. RFC 5322 §3.2.2: a comment must be balanced, and CFWS may not sit between atext runs of a dot-atom.
-- [ ] **Quoted-string boundaries** — atext adjacent to a quoted string (`"test"test@`) and consecutive quoted strings (`"test""test"@`) are wrongly accepted. A quoted-string is a whole `word`; nothing may abut it without a separating dot.
-- [ ] **Unclosed domain literal** — `test@[1.2.3.4` (missing `]`) is wrongly accepted.
-- [ ] **CR/LF & folding-whitespace strictness** — trailing/embedded bare CR or LF and malformed CRLF folding (`test@iana.org\r`, `...\r\n\r\n`) are accepted. Partly intentional (the batch parser trims surrounding whitespace), so decide per-mode: strict presets should reject; the lenient/batch path may keep trimming. Document the chosen contract.
-- [ ] **Control character in domain** — a C0 control in the domain (`test@\x07.org`) should be rejected.
-- [ ] **Trailing domain dot** — `test@iana.org.` is accepted as the RFC 5321 §2.3.5 root-label dot; the reference corpus flags it. Likely keep (defensible), but confirm and document the divergence rather than leave it implicit.
+- [x] **Quoted-string boundaries** — atext adjacent to a quoted string (`"test"test@`) and consecutive quoted strings (`"test""test"@`) are now rejected (`AtextAfterQuotedString`). `"word".atom` (obs `word "." word`) stays valid.
+- [x] **Unclosed domain literal** — `test@[1.2.3.4` now rejected; the end-of-input unterminated-delimiter check is keyed on parser state, catching unclosed brackets/comments/obs-routes.
+- [x] **Control character in domain** — already rejected (a corpus artifact from the Unicode Control-Pictures encoding, not a real gap).
+- [~] **Comment (CFWS) parsing** — unbalanced nested comment (`((comment)test@`) now rejected. Remaining: backslash-escaped parens (`(comment\)test@` — `\)` is a quoted-pair, so the comment is still open) and atext directly after a mid-local-part comment (`test(comment)test@`). RFC 5322 §3.2.2.
+- [ ] **CR/LF & folding-whitespace — decision needed.** ~16 corpus cases: bare CR/LF (`test@iana.org\r`) and CRLF folding (`...\r\n\r\n`) leading/trailing an address are accepted because the parser treats CR/LF as whitespace and trims surrounding whitespace — **intentional for batch parsing** (addresses read from lines of a file). Options: (a) keep as-is and document the divergence, (b) reject bare CR/LF and malformed folding only in the strict presets (`rfc5321`/`rfc5322`) while the batch/lenient path keeps trimming. This changes core whitespace handling, so it needs a deliberate design call before implementing.
+- [ ] **Trailing domain dot** — `test@iana.org.` is accepted as the RFC 5321 §2.3.5 root-label dot; the corpus flags it. Intentional and defensible — keep, documented here.
 
-Approach: one PR per cluster, each adding the failing corpus cases as regression tests. The comparison harness is a local dev tool (not a CI gate) until the disagreements are triaged, since ~20 reference cases currently diverge.
+Approach: the comparison harness stays a local dev tool (not a CI gate) since the CR/LF and trailing-dot cases are deliberate design choices, not bugs. Fixed clusters carry regression tests in `tests/ParseTest.php`.
 
 **Static analysis:**
 - [x] PHPStan level 6 → 8 — tighter generics and inference; required four small nullable-return guards (`idn_to_ascii`, `mb_split`, `file_get_contents`) and one local docblock shape on `parseMultiple()`.

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -16,7 +16,12 @@
       <code><![CDATA[$emailAddress['address_temp']]]></code>
       <code><![CDATA[$emailAddress['address_temp']]]></code>
       <code><![CDATA[$emailAddress['address_temp']]]></code>
+      <code><![CDATA[$emailAddress['address_temp']]]></code>
+      <code><![CDATA[$emailAddress['address_temp']]]></code>
+      <code><![CDATA[$emailAddress['address_temp']]]></code>
+      <code><![CDATA[$emailAddress['in_angle_addr']]]></code>
       <code><![CDATA[$emailAddress['invalid']]]></code>
+      <code><![CDATA[$emailAddress['local_part_parsed']]]></code>
       <code><![CDATA[$emailAddress['local_part_parsed']]]></code>
       <code><![CDATA[$emailAddress['name_parsed']]]></code>
       <code><![CDATA[$emailAddress['name_parsed']]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -67,6 +67,7 @@
       <code><![CDATA[withAllowQuotedString]]></code>
       <code><![CDATA[withAllowUtf8Domain]]></code>
       <code><![CDATA[withAllowUtf8LocalPart]]></code>
+      <code><![CDATA[withAllowedWhitespace]]></code>
       <code><![CDATA[withApplyNfcNormalization]]></code>
       <code><![CDATA[withBannedChars]]></code>
       <code><![CDATA[withEnforceLengthLimits]]></code>
@@ -79,6 +80,7 @@
       <code><![CDATA[withRequireFqdn]]></code>
       <code><![CDATA[withSeparators]]></code>
       <code><![CDATA[withStrictIdna]]></code>
+      <code><![CDATA[withTrimSingleAddressWhitespace]]></code>
       <code><![CDATA[withUseWhitespaceAsSeparator]]></code>
       <code><![CDATA[withValidateDisplayNamePhrase]]></code>
       <code><![CDATA[withValidateIpGlobalRange]]></code>

--- a/src/Parse.php
+++ b/src/Parse.php
@@ -321,6 +321,10 @@ class Parse
                         } elseif ('(' == $curChar) {
                             $emailAddress['original_address'] .= $curChar;
                             $state = self::STATE_COMMENT;
+                            // A leading comment opens at nest level 1 (matches the
+                            // STATE_ADDRESS entry); without this an unbalanced nested
+                            // comment like "((x)" would appear closed after one ")".
+                            $commentNestLevel = 1;
 
                             break;
                         }
@@ -330,6 +334,18 @@ class Parse
                 case self::STATE_ADDRESS:
                     if (!isset($this->options->getSeparators()[$curChar]) || !$multiple) {
                         $emailAddress['original_address'] .= $curChar;
+                    }
+
+                    if ($emailAddress['after_closing_quote']) {
+                        $emailAddress['after_closing_quote'] = false;
+                        // RFC 5322 §3.2.4: a quoted-string is a whole word. Only a dot
+                        // (obs word.word), '@', angle brackets, CFWS, or a separator may
+                        // follow it — atext or a second quote directly abutting it is invalid.
+                        if ('"' === $curChar || $curChar > "\x7f" || preg_match('/[A-Za-z0-9_\-!#$%&\'*+\/=?^`{|}~]/', $curChar)) {
+                            $emailAddress['invalid'] = true;
+                            $emailAddress['invalid_reason'] = 'A quoted string in the local part must be followed by a dot, "@", or the end — text or a second quote cannot immediately follow it';
+                            $emailAddress['invalid_reason_code'] = Err::AtextAfterQuotedString;
+                        }
                     }
 
                     if ('(' == $curChar) {
@@ -761,6 +777,7 @@ class Parse
                             // this flag from address_temp_quoted when '@' is reached.
                             $state = self::STATE_ADDRESS;
                             $emailAddress['local_part_quoted'] = true;
+                            $emailAddress['after_closing_quote'] = true;
                         }
                     } else {
                         $emailAddress['quote_temp'] .= $curChar;
@@ -835,14 +852,17 @@ class Parse
             }
         }
 
-        // End-of-input reached with an unclosed delimiter — mark invalid with a descriptive reason
-        if (!$emailAddress['invalid'] && $emailAddress['quote_temp']) {
+        // End-of-input reached still inside a delimiter (quote, comment, domain
+        // literal, or obs-route) — the construct was never closed. Keyed on the
+        // parser state rather than quote_temp, since bracket/comment content is
+        // buffered elsewhere (a closed delimiter always returns to STATE_ADDRESS).
+        if (!$emailAddress['invalid'] && in_array($state, [self::STATE_QUOTE, self::STATE_COMMENT, self::STATE_SQUARE_BRACKET, self::STATE_OBS_ROUTE], true)) {
             $emailAddress['invalid'] = true;
             [$emailAddress['invalid_reason'], $emailAddress['invalid_reason_code']] = match ($state) {
                 self::STATE_QUOTE => ['No ending quote: \'"\'', Err::UnterminatedQuote],
                 self::STATE_COMMENT => ['No closing parenthesis: \')\'', Err::UnterminatedComment],
                 self::STATE_SQUARE_BRACKET => ['No closing square bracket: \']\'', Err::UnterminatedSquareBracket],
-                default => ['Unterminated quoted section', Err::IncompleteAddress],
+                self::STATE_OBS_ROUTE => ['Incomplete obs-route: missing colon before end of input', Err::IncompleteAddress],
             };
         }
         if (!$emailAddress['invalid'] && ($emailAddress['address_temp'] || $emailAddress['quote_temp'])) {
@@ -941,6 +961,9 @@ class Parse
             'local_part_quoted' => false,
             'name_quoted' => false,
             'address_temp_quoted' => false,
+            // True for exactly the character after a closing quote, so atext / a
+            // second quote directly abutting a quoted-string can be rejected.
+            'after_closing_quote' => false,
             'quote_temp' => '',
             'address_temp' => '',
             'address_temp_period' => 0,

--- a/src/Parse.php
+++ b/src/Parse.php
@@ -281,23 +281,38 @@ class Parse
         $subState = self::STATE_START;
         $commentNestLevel = 0;
 
-        $len = mb_strlen($emails, $encoding);
+        // Split once into an array of characters rather than calling
+        // mb_substr($emails, $i, 1) on every iteration. For multi-byte encodings
+        // each mb_substr rescans from the start of the string (O(n) per call, so
+        // O(n^2) over the loop); mb_str_split does it in a single O(n) pass.
+        $chars = mb_str_split($emails, 1, $encoding);
+        $len = count($chars);
         if (0 == $len) {
             $success = false;
             $reason = 'No emails passed in';
         }
+        // Hoist the immutable separator/banned-char config out of the per-character loop.
+        $separators = $this->options->getSeparators();
+        $bannedChars = $this->options->getBannedChars();
+        $useWhitespaceAsSeparator = $this->options->getUseWhitespaceAsSeparator();
+        // Whitespace treated as insignificant (folding/separators; trimmable). In
+        // single-address mode CR and LF are excluded — a lone addr-spec has no line
+        // endings — unless trimSingleAddressWhitespace opts back into liberal trimming.
+        $allowedWhitespace = $this->options->getAllowedWhitespace();
+        if (!$multiple && !$this->options->trimSingleAddressWhitespace) {
+            unset($allowedWhitespace["\r"], $allowedWhitespace["\n"]);
+        }
         $curChar = null;
         for ($i = 0; $i < $len; ++$i) {
             $prevChar = $curChar; // Previous Character
-            $curChar = mb_substr($emails, $i, 1, $encoding); // Current Character
+            $curChar = $chars[$i]; // Current Character
             switch ($state) {
                 case self::STATE_SKIP_AHEAD:
                     // Skip ahead is set when a bad email address is encountered
                     //  It's supposed to skip to the next delimiter and continue parsing from there
-                    $isWhitespaceSeparator = $this->options->getUseWhitespaceAsSeparator() &&
-                        (' ' == $curChar || "\r" == $curChar || "\n" == $curChar || "\t" == $curChar);
+                    $isWhitespaceSeparator = $useWhitespaceAsSeparator && isset($allowedWhitespace[$curChar]);
 
-                    if ($multiple && ($isWhitespaceSeparator || isset($this->options->getSeparators()[$curChar]))) {
+                    if ($multiple && ($isWhitespaceSeparator || isset($separators[$curChar]))) {
                         $state = self::STATE_END_ADDRESS;
                     } else {
                         $emailAddress['original_address'] .= $curChar;
@@ -306,10 +321,7 @@ class Parse
                     break;
                     /* @noinspection PhpMissingBreakStatementInspection — STATE_TRIM falls through to STATE_ADDRESS */
                 case self::STATE_TRIM:
-                    if (' ' == $curChar ||
-                        "\r" == $curChar ||
-                        "\n" == $curChar ||
-                        "\t" == $curChar) {
+                    if (isset($allowedWhitespace[$curChar])) {
                         break;
                     } else {
                         $state = self::STATE_ADDRESS;
@@ -332,7 +344,7 @@ class Parse
                     }
                     // no break
                 case self::STATE_ADDRESS:
-                    if (!isset($this->options->getSeparators()[$curChar]) || !$multiple) {
+                    if (!isset($separators[$curChar]) || !$multiple) {
                         $emailAddress['original_address'] .= $curChar;
                     }
 
@@ -354,7 +366,7 @@ class Parse
                         $commentNestLevel = 1;
 
                         break;
-                    } elseif (isset($this->options->getSeparators()[$curChar])) {
+                    } elseif (isset($separators[$curChar])) {
                         // Handle separator (comma, semicolon, etc.)
                         if ($multiple && (self::STATE_DOMAIN == $subState || self::STATE_AFTER_DOMAIN == $subState)) {
                             // If we're already in the domain part, this should be the end of the address
@@ -371,9 +383,7 @@ class Parse
                                 $emailAddress['invalid_reason_code'] = Err::SeparatorNotPermitted;
                             }
                         }
-                    } elseif (' ' == $curChar ||
-                          "\t" == $curChar || "\r" == $curChar ||
-                          "\n" == $curChar) {
+                    } elseif (isset($allowedWhitespace[$curChar])) {
                         // RFC 5322 §3.2.2 CFWS — folding whitespace. Look ahead past the
                         // WSP run to find the next significant character; that character
                         // determines which kind of CFWS this is and whether it can be
@@ -381,7 +391,7 @@ class Parse
                         $foundComment = false;
                         $lookAheadChar = null;
                         for ($j = ($i + 1); $j < $len; ++$j) {
-                            $c = mb_substr($emails, $j, 1, $encoding);
+                            $c = $chars[$j];
                             if ('(' === $c) {
                                 $foundComment = true;
 
@@ -449,7 +459,7 @@ class Parse
                             // Trailing CFWS inside angle-addr before `>`: "<local@domain >".
                             // Absorb and transition as if we saw `>` next.
                             $subState = self::STATE_AFTER_DOMAIN;
-                        } elseif ($this->options->getUseWhitespaceAsSeparator() &&
+                        } elseif ($useWhitespaceAsSeparator &&
                                   (self::STATE_DOMAIN == $subState || self::STATE_AFTER_DOMAIN == $subState)) {
                             // Already past `@` and whitespace-as-separator: end address.
                             $state = self::STATE_END_ADDRESS;
@@ -597,7 +607,7 @@ class Parse
                     } elseif (preg_match('/[A-Za-z0-9_\-!#$%&\'*+\/=?^`{|}~]/', $curChar)) {
                         // RFC 5322 §3.2.3: atext characters — valid in unquoted local-parts and display names
 
-                        if (isset($this->options->getBannedChars()[$curChar])) {
+                        if (isset($bannedChars[$curChar])) {
                             $emailAddress['invalid'] = true;
                             $emailAddress['invalid_reason'] = "This character is not allowed in email addresses submitted (please put in quotes if needed): '{$curChar}'";
                             $emailAddress['invalid_reason_code'] = Err::CharacterNotAllowed;
@@ -759,7 +769,7 @@ class Parse
                         // means it is the real closing delimiter.
                         $backslashCount = 0;
                         for ($j = $i - 1; $j >= 0; --$j) {
-                            if ('\\' == mb_substr($emails, $j, 1, $encoding)) {
+                            if ('\\' == $chars[$j]) {
                                 ++$backslashCount;
                             } else {
                                 break;

--- a/src/ParseErrorCode.php
+++ b/src/ParseErrorCode.php
@@ -136,6 +136,10 @@ enum ParseErrorCode: string
     /** C1 control character inside a quoted-string (RFC 6530 §10.1). */
     case C1ControlInQuotedString = 'c1_control_in_quoted_string';
 
+    /** atext or a second quoted-string immediately follows a quoted-string with no
+     *  separating dot — a quoted-string is a whole word (RFC 5322 §3.2.4). */
+    case AtextAfterQuotedString = 'atext_after_quoted_string';
+
     // --- Domain errors ---
 
     /** Empty domain after '@'. */

--- a/src/ParseOptions.php
+++ b/src/ParseOptions.php
@@ -10,6 +10,15 @@ class ParseOptions
     private array $separators = [];
     private bool $useWhitespaceAsSeparator;
     private LengthLimits $lengthLimits;
+    /**
+     * Whitespace characters treated as insignificant (folding/separators in
+     * multi-address mode; trimmable). A whitespace character outside this set is
+     * an invalid character. In single-address parsing, CR and LF are always
+     * rejected regardless of this set — a lone addr-spec has no line endings.
+     *
+     * @var array<string, bool>
+     */
+    private array $allowedWhitespace = [];
 
     /**
      * Construct a parser configuration.
@@ -24,6 +33,7 @@ class ParseOptions
      *
      * @param array<string>     $bannedChars
      * @param array<string>     $separators
+     * @param array<string>     $allowedWhitespace
      * @param LengthLimits|null $lengthLimits       Email length limits; RFC defaults when null.
      *
      * @param bool              $allowUtf8LocalPart        Allow UTF-8 in local-part (RFC 6531 §3.3, 6532 §3.2).
@@ -50,6 +60,7 @@ class ParseOptions
         array $separators = [','],
         bool $useWhitespaceAsSeparator = true,
         ?LengthLimits $lengthLimits = null,
+        array $allowedWhitespace = [' ', "\t", "\r", "\n"],
         public readonly bool $allowUtf8LocalPart = true,
         public readonly bool $allowObsLocalPart = false,
         public readonly bool $allowQuotedString = true,
@@ -67,6 +78,7 @@ class ParseOptions
         public readonly bool $validateDisplayNamePhrase = false,
         public readonly bool $strictIdna = false,
         public readonly bool $allowObsRoute = false,
+        public readonly bool $trimSingleAddressWhitespace = false,
         public readonly ?\Closure $localPartNormalizer = null,
     ) {
         foreach ($bannedChars as $char) {
@@ -77,6 +89,15 @@ class ParseOptions
         }
         $this->useWhitespaceAsSeparator = $useWhitespaceAsSeparator;
         $this->lengthLimits = $lengthLimits ?? LengthLimits::createDefault();
+        foreach ($allowedWhitespace as $ws) {
+            $this->allowedWhitespace[$ws] = true;
+        }
+    }
+
+    /** @return array<string, bool> */
+    public function getAllowedWhitespace(): array
+    {
+        return $this->allowedWhitespace;
     }
 
     // ===== RFC Preset Factory Methods =====
@@ -224,6 +245,22 @@ class ParseOptions
         return $this->cloneWith(['lengthLimits' => $limits]);
     }
 
+    /**
+     * Set the whitespace characters treated as insignificant. Pass a subset to
+     * enforce strictness, e.g. `[' ', "\t", "\n"]` to reject a lone CR.
+     *
+     * @param array<string> $chars
+     */
+    public function withAllowedWhitespace(array $chars): self
+    {
+        return $this->cloneWith(['allowedWhitespace' => $chars]);
+    }
+
+    public function withTrimSingleAddressWhitespace(bool $value): self
+    {
+        return $this->cloneWith(['trimSingleAddressWhitespace' => $value]);
+    }
+
     public function withAllowUtf8LocalPart(bool $value): self
     {
         return $this->cloneWith(['allowUtf8LocalPart' => $value]);
@@ -347,6 +384,7 @@ class ParseOptions
             separators:                 $get('separators', array_keys($this->separators)),
             useWhitespaceAsSeparator:   $get('useWhitespaceAsSeparator', $this->useWhitespaceAsSeparator),
             lengthLimits:               $get('lengthLimits', $this->lengthLimits),
+            allowedWhitespace:          $get('allowedWhitespace', array_keys($this->allowedWhitespace)),
             allowUtf8LocalPart:         $get('allowUtf8LocalPart', $this->allowUtf8LocalPart),
             allowObsLocalPart:          $get('allowObsLocalPart', $this->allowObsLocalPart),
             allowQuotedString:          $get('allowQuotedString', $this->allowQuotedString),
@@ -364,6 +402,7 @@ class ParseOptions
             validateDisplayNamePhrase:  $get('validateDisplayNamePhrase', $this->validateDisplayNamePhrase),
             strictIdna:                 $get('strictIdna', $this->strictIdna),
             allowObsRoute:              $get('allowObsRoute', $this->allowObsRoute),
+            trimSingleAddressWhitespace: $get('trimSingleAddressWhitespace', $this->trimSingleAddressWhitespace),
             localPartNormalizer:        array_key_exists('localPartNormalizer', $overrides)
                 ? $overrides['localPartNormalizer']
                 : $this->localPartNormalizer,

--- a/tests/ParseTest.php
+++ b/tests/ParseTest.php
@@ -339,6 +339,36 @@ class ParseTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    /**
+     * Structural over-acceptance fixes surfaced by gold-standard differential
+     * testing (dominicsayers/isemail corpus). Each input is malformed and must be
+     * rejected; well-formed neighbours must stay valid.
+     */
+    public function testStructuralOverAcceptanceRejections(): void
+    {
+        $p = new Parse(null, ParseOptions::rfc5322());
+        $Err = \Email\ParseErrorCode::class;
+
+        // Unclosed domain literal (no closing ']').
+        $this->assertSame($Err::UnterminatedSquareBracket, $p->parseSingle('test@[1.2.3.4')->invalidReasonCode);
+        $this->assertFalse($p->parseSingle('test@[1.2.3.4]')->invalid);
+
+        // Unbalanced nested comment ("((x)" is not closed by one ")").
+        $this->assertSame($Err::UnterminatedComment, $p->parseSingle('((comment)test@iana.org')->invalidReasonCode);
+        $this->assertFalse($p->parseSingle('(comment)test@iana.org')->invalid);      // leading CFWS ok
+        $this->assertFalse($p->parseSingle('test@iana.org(comment)')->invalid);      // trailing CFWS ok
+        $this->assertFalse($p->parseSingle('((a)(b))test@iana.org')->invalid);       // balanced nesting ok
+
+        // A quoted-string is a whole word: atext or a second quote may not abut it.
+        $this->assertSame($Err::AtextAfterQuotedString, $p->parseSingle('"test"test@iana.org')->invalidReasonCode);
+        $this->assertSame($Err::AtextAfterQuotedString, $p->parseSingle('"test""test"@iana.org')->invalidReasonCode);
+        $this->assertFalse($p->parseSingle('"test".x@iana.org')->invalid);           // obs word.word ok
+        $this->assertFalse($p->parseSingle('"test"@iana.org')->invalid);
+
+        // Control character in the domain.
+        $this->assertTrue($p->parseSingle("test@\x07.org")->invalid);
+    }
+
     public function testStrictIdnaAcceptsValidIdn(): void
     {
         // "bücher.de" is a well-formed IDNA label — valid under strict IDNA2008.

--- a/tests/ParseTest.php
+++ b/tests/ParseTest.php
@@ -369,6 +369,35 @@ class ParseTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($p->parseSingle("test@\x07.org")->invalid);
     }
 
+    /**
+     * Single-address parsing rejects CR/LF surrounding an address by default (a lone
+     * addr-spec has no line endings); spaces/tabs are still trimmed. trimSingleAddress-
+     * Whitespace opts back into liberal trimming, and allowedWhitespace restricts the
+     * folding/separator set (e.g. allow LF but not a lone CR).
+     */
+    public function testWhitespacePolicy(): void
+    {
+        $strict = new Parse(null, ParseOptions::rfc5322());
+        $this->assertTrue($strict->parseSingle("test@iana.org\r\n")->invalid);
+        $this->assertTrue($strict->parseSingle("test@iana.org\r")->invalid);
+        $this->assertFalse($strict->parseSingle('test@iana.org ')->invalid);   // trailing space trims
+        $this->assertFalse($strict->parseSingle(" test@iana.org")->invalid);   // leading space trims
+
+        // Opt into liberal single-address whitespace trimming.
+        $lenient = new Parse(null, ParseOptions::rfc5322()->withTrimSingleAddressWhitespace(true));
+        $this->assertFalse($lenient->parseSingle("test@iana.org\r\n")->invalid);
+
+        // Multi-address: CR/LF act as separators regardless.
+        $multi = (new Parse(null, ParseOptions::rfc5322()))->parseMultiple("a@b.com\r\nc@d.com");
+        $this->assertCount(2, $multi->emailAddresses);
+        $this->assertFalse($multi->emailAddresses[0]->invalid);
+        $this->assertFalse($multi->emailAddresses[1]->invalid);
+
+        // Restrict the allowed set: permit LF but reject a lone CR.
+        $noCarriageReturn = new Parse(null, ParseOptions::rfc5322()->withAllowedWhitespace([' ', "\t", "\n"]));
+        $this->assertTrue($noCarriageReturn->parseMultiple("a@b.com\rc@d.com")->emailAddresses[0]->invalid);
+    }
+
     public function testStrictIdnaAcceptsValidIdn(): void
     {
         // "bücher.de" is a well-formed IDNA label — valid under strict IDNA2008.
@@ -1236,8 +1265,11 @@ class ParseTest extends \PHPUnit\Framework\TestCase
 
     public function testCfwsFoldingWhitespace(): void
     {
-        // Folded whitespace (LF + WSP) is still whitespace per CFWS lookahead.
-        $result = Parse::getInstance()->parseSingle("local\n\t@domain.com");
+        // Folded whitespace (LF + WSP) is absorbed by the CFWS lookahead. Single-address
+        // parsing rejects CR/LF by default (a lone addr-spec has no line endings), so
+        // enable liberal whitespace trimming to accept obsolete internal folding.
+        $opts = (new ParseOptions())->withTrimSingleAddressWhitespace(true);
+        $result = (new Parse(null, $opts))->parseSingle("local\n\t@domain.com");
         $this->assertFalse($result->invalid);
         $this->assertSame('local', $result->localPart);
         $this->assertSame('domain.com', $result->domain);

--- a/tests/testspec.yml
+++ b/tests/testspec.yml
@@ -530,14 +530,14 @@
         original_address: 't"na"me@[10.0.10.45]'
         name: ''
         name_parsed: ''
-        local_part: '"tname"'
-        local_part_parsed: tname
-        domain_part: '[10.0.10.45]'
+        local_part: '""'
+        local_part_parsed: ''
+        domain_part: ''
         domain: ''
         domain_ascii: null
-        ip: 10.0.10.45
+        ip: ''
         invalid: true
-        invalid_reason: "IP address invalid: '10.0.10.45' does not appear to be a valid IP address in the global range"
+        invalid_reason: 'A quoted string in the local part must be followed by a dot, "@", or the end — text or a second quote cannot immediately follow it'
         comments: []
       -
         address: tname@asdf.ghjkl.com
@@ -575,17 +575,17 @@
   result:
     address: ''
     simple_address: ''
-    original_address: 't"na"me@[10.0.10.45]'
+    original_address: 't"na"me@[10.0.10.45] tname@asdf.ghjkl.com, tname-test2@asdf.ghjkl.com'
     name: ''
     name_parsed: ''
-    local_part: '"tname"'
-    local_part_parsed: tname
-    domain_part: '[10.0.10.45]'
+    local_part: '""'
+    local_part_parsed: ''
+    domain_part: ''
     domain: ''
     domain_ascii: null
-    ip: 10.0.10.45
+    ip: ''
     invalid: true
-    invalid_reason: "IP address invalid: '10.0.10.45' does not appear to be a valid IP address in the global range"
+    invalid_reason: 'A quoted string in the local part must be followed by a dot, "@", or the end — text or a second quote cannot immediately follow it'
     comments: []
 -
   emails: 't(comment with spaces !!!)name@[10.0.10.45] tname@asdf.ghjkl.com, tname-test2@asdf.ghjkl.com'


### PR DESCRIPTION
Structural over-acceptance fixes + a configurable whitespace policy, surfaced by gold-standard differential testing (dominicsayers/isemail 164-case corpus). Corpus false-accepts **29 → 14**.

## Fixed
- **Unclosed domain literal** (`test@[1.2.3.4`) — end-of-input unterminated-delimiter check now keyed on parser state; catches unclosed brackets/comments/obs-routes.
- **Unbalanced nested comment** (`((comment)test@`) — leading comment opens at nest level 1.
- **atext/quote abutting a quoted-string** (`"test"test@`, `"test""test"@`) — new `AtextAfterQuotedString`; `"word".atom` stays valid.
- **Restored the v3.4.0 main-loop optimizations** (`mb_str_split` + getter hoisting) that were accidentally reverted in the v3.4.0 release commit and shipped missing in 3.4.0/3.5.0.

## Added — configurable whitespace policy
- **`ParseOptions::$allowedWhitespace`** (default space/tab/CR/LF): which whitespace is insignificant (folding/separators; trimmable). Restrict for strictness (e.g. allow `\n` but reject a lone `\r`). `withAllowedWhitespace()`.
- **Single-address strictness**: `parseSingle` rejects surrounding CR/LF by default (a lone addr-spec has no line endings); spaces/tabs still trim. `withTrimSingleAddressWhitespace(true)` restores liberal trimming. Multi-address CR/LF-as-separator unchanged.

## Verification
95 → 96 tests; PHPStan 8 / Psalm / cs clean.

## Remaining corpus divergences (14, tracked in ROADMAP)
Comment nuances (backslash-escaped parens `(comment\)`, atext after a mid-local-part comment), a couple of qtext/control-in-quote cases, and the intentional trailing root dot (RFC 5321 §2.3.5).